### PR TITLE
地図情報管理ページにDBから取得した情報を表示するように

### DIFF
--- a/WebContent/css/src/map.css
+++ b/WebContent/css/src/map.css
@@ -35,13 +35,18 @@
   width: 200px;
 }
 
-div.map_image_path {
+div#map_image_path {
   position: relative;
   background-color: white;
   width: 100%;
   height: 400px;
   color: #CCCCCC;
   text-align: center;
+}
+
+.map_image_img {
+  max-width: 590px;
+  max-height: 400px;
 }
 
 .map_image_trash {

--- a/WebContent/js/src/album.js
+++ b/WebContent/js/src/album.js
@@ -155,7 +155,7 @@ $(function(){
   /*
     Main Part
   */
-  // セッションIDからサービス情報を取得する
+  // セッションIDからアルバム情報を取得する
   var session_info = getSessionInfo();
   var album_info = getAlbumInfo(session_info.t_hairSalonMaster_salonId);
 

--- a/WebContent/js/src/common.js
+++ b/WebContent/js/src/common.js
@@ -152,6 +152,21 @@ var getHairTypeList = (function(){
     };
 })();
 
+// 地図情報を取得する関数
+var getMapInfo = (function(data){
+    return function() {
+        var response = $.ajax({
+            type: "POST",
+            url: "./getMapInfo",
+            async: false,
+            data: data,
+        }).responseText;
+
+        response = JSON.parse(response);
+        return response;
+    };
+})();
+
 // リロードボタン押下時
 $('#reload_button').on('click', function() {
     window.location.reload();

--- a/WebContent/js/src/coupon.js
+++ b/WebContent/js/src/coupon.js
@@ -176,7 +176,7 @@ $(function(){
   /*
     Main Part
   */
-  // セッションIDからサービス情報を取得する
+  // セッションIDからクーポン情報を取得する
   var session_info = getSessionInfo();
   var coupon_info = getCouponInfo(session_info.t_hairSalonMaster_salonId);
 

--- a/WebContent/js/src/jsx/album.js
+++ b/WebContent/js/src/jsx/album.js
@@ -155,7 +155,7 @@ $(function(){
   /*
     Main Part
   */
-  // セッションIDからサービス情報を取得する
+  // セッションIDからアルバム情報を取得する
   var session_info = getSessionInfo();
   var album_info = getAlbumInfo(session_info.t_hairSalonMaster_salonId);
 

--- a/WebContent/js/src/jsx/coupon.js
+++ b/WebContent/js/src/jsx/coupon.js
@@ -176,7 +176,7 @@ $(function(){
   /*
     Main Part
   */
-  // セッションIDからサービス情報を取得する
+  // セッションIDからクーポン情報を取得する
   var session_info = getSessionInfo();
   var coupon_info = getCouponInfo(session_info.t_hairSalonMaster_salonId);
 

--- a/WebContent/js/src/jsx/map.js
+++ b/WebContent/js/src/jsx/map.js
@@ -1,0 +1,58 @@
+$(function(){
+  /*
+    Component for React
+  */
+  // コンポーネントの定義
+  var MapUrl = React.createClass({
+    getInitialState() {
+      return {
+        t_hairSalonMaster_mapUrl: ""
+      };
+    },
+    changeText(e) {
+      this.setState({t_hairSalonMaster_mapUrl: e.target.value});
+    },
+    render() {
+      return (
+        <div>
+          <input type="text" value={this.state.t_hairSalonMaster_mapUrl} onChange={this.changeText} />
+        </div>
+      );
+    }
+  });
+
+  var MapImagePath = React.createClass({
+    getInitialState() {
+      return {
+        t_hairSalonMaster_mapImagePath: "img/notfound.jpg"
+      };
+    },
+    render() {
+      return (
+        <div>
+          <img className="map_image_img" src={this.state.t_hairSalonMaster_mapImagePath?this.state.t_hairSalonMaster_mapImagePath:'img/notfound.jpg'} />
+        </div>
+      );
+    }
+  });
+
+
+  /*
+    Component Render
+  */
+  // コンポーネントをエレメントに割り当てる
+  var component_map_url = React.render(<MapUrl />, document.getElementById('map_url'));
+  var component_map_image_path = React.render(<MapImagePath />, document.getElementById('map_image_path'));
+
+
+  /*
+    Main Part
+  */
+  // セッションIDから地図情報を取得する
+  var session_info = getSessionInfo();
+  var map_info = getMapInfo(session_info.t_hairSalonMaster_salonId);
+
+  // コンポーネントにjsonを渡して関係する部分だけ書き換わる
+  component_map_url.setState(map_info);
+  component_map_image_path.setState(map_info);
+});

--- a/WebContent/js/src/map.js
+++ b/WebContent/js/src/map.js
@@ -1,0 +1,58 @@
+$(function(){
+  /*
+    Component for React
+  */
+  // コンポーネントの定義
+  var MapUrl = React.createClass({displayName: "MapUrl",
+    getInitialState:function() {
+      return {
+        t_hairSalonMaster_mapUrl: ""
+      };
+    },
+    changeText:function(e) {
+      this.setState({t_hairSalonMaster_mapUrl: e.target.value});
+    },
+    render:function() {
+      return (
+        React.createElement("div", null, 
+          React.createElement("input", {type: "text", value: this.state.t_hairSalonMaster_mapUrl, onChange: this.changeText})
+        )
+      );
+    }
+  });
+
+  var MapImagePath = React.createClass({displayName: "MapImagePath",
+    getInitialState:function() {
+      return {
+        t_hairSalonMaster_mapImagePath: "img/notfound.jpg"
+      };
+    },
+    render:function() {
+      return (
+        React.createElement("div", null, 
+          React.createElement("img", {className: "map_image_img", src: this.state.t_hairSalonMaster_mapImagePath?this.state.t_hairSalonMaster_mapImagePath:'img/notfound.jpg'})
+        )
+      );
+    }
+  });
+
+
+  /*
+    Component Render
+  */
+  // コンポーネントをエレメントに割り当てる
+  var component_map_url = React.render(React.createElement(MapUrl, null), document.getElementById('map_url'));
+  var component_map_image_path = React.render(React.createElement(MapImagePath, null), document.getElementById('map_image_path'));
+
+
+  /*
+    Main Part
+  */
+  // セッションIDから地図情報を取得する
+  var session_info = getSessionInfo();
+  var map_info = getMapInfo(session_info.t_hairSalonMaster_salonId);
+
+  // コンポーネントにjsonを渡して関係する部分だけ書き換わる
+  component_map_url.setState(map_info);
+  component_map_image_path.setState(map_info);
+});

--- a/WebContent/map.html
+++ b/WebContent/map.html
@@ -119,7 +119,7 @@
                                     <label for="map_url">Baidu API(リンク)：</label>
                                 </td>
                                 <td>
-                                    <input id="map_url" type="text" size="20">
+                                    <div id="map_url"></div>
                                 </td>
                             </tr>
                             <tr>
@@ -132,7 +132,7 @@
                             </tr>
                             <tr>
                                 <td colspan="2">
-                                    <div class="map_image_path">No Picture</div>
+                                    <div id="map_image_path"></div>
                                 </td>
                             </tr>
                             <tr>
@@ -178,9 +178,14 @@
 <script src="vendor/jquery-touchswipe/jquery.touchSwipe.js"></script>
 <script src="vendor/jquery-touchswipe/jquery.touchSwipe.js"></script>
 
+<!-- react -->
+<script src="js/react.min.js"></script>
+<script src="js/JSXTransformer.js"></script>
+
 <!-- common app js -->
 <script src="js/app.min.js"></script>
 <script src="js/common.min.js"></script>
+<script src="js/map.min.js"></script>
 
 <!-- common app js -->
 <script src="js/settings.js"></script>


### PR DESCRIPTION
issue：#4

* 地図情報管理ページにDBから取得した地図URLと地図画像を埋め込むように
* クーポンとアルバムのjsに記入されたコメントを修正

## スクリーンショット

![2015-06-21 23 16 38](https://cloud.githubusercontent.com/assets/9024344/8271945/271db644-186c-11e5-9604-1eb08c14c28f.png)

```json
{
  "t_hairSalonMaster_mapUrl": "http://sample.url.com",
  "t_hairSalonMaster_mapImagePath": "img/avatar.png"
}
```

### 画像がない場合
![2015-06-21 23 19 20](https://cloud.githubusercontent.com/assets/9024344/8271946/29cfb748-186c-11e5-9037-3fcc983d5d1d.png)

```json
{
  "t_hairSalonMaster_mapUrl": "http://sample.url.com",
  "t_hairSalonMaster_mapImagePath": ""
}
```
