### PR TITLE
画像削除ボタンを実装

### DIFF
--- a/WebContent/js/src/jsx/map.js
+++ b/WebContent/js/src/jsx/map.js
@@ -101,4 +101,9 @@ $(function(){
       }
     }
   });
+
+  // 画像削除ボタン
+  $('.map_image_trash_button').on('click', function() {
+    component_map_image_path.setState({t_hairSalonMaster_mapImagePath: 'img/notfound.jpg'});
+  });
 });

--- a/WebContent/js/src/jsx/salon.js
+++ b/WebContent/js/src/jsx/salon.js
@@ -439,4 +439,12 @@ $(function(){
     }
   });
 
+  // 画像削除ボタン
+  $('.salon_image_trash_button').on('click', function() {
+    var id = $(".salon_image_trash_button").index(this);
+    var current_image_path = component_salon_image_path.state.t_hairSalonMaster_salonImagePath;
+    current_image_path[id] = 'img/notfound.jpg';
+    component_salon_image_path.setState({t_hairSalonMaster_salonImagePath: current_image_path});
+  });
+
 });

--- a/WebContent/js/src/map.js
+++ b/WebContent/js/src/map.js
@@ -101,4 +101,9 @@ $(function(){
       }
     }
   });
+
+  // 画像削除ボタン
+  $('.map_image_trash_button').on('click', function() {
+    component_map_image_path.setState({t_hairSalonMaster_mapImagePath: 'img/notfound.jpg'});
+  });
 });

--- a/WebContent/js/src/salon.js
+++ b/WebContent/js/src/salon.js
@@ -439,4 +439,12 @@ $(function(){
     }
   });
 
+  // 画像削除ボタン
+  $('.salon_image_trash_button').on('click', function() {
+    var id = $(".salon_image_trash_button").index(this);
+    var current_image_path = component_salon_image_path.state.t_hairSalonMaster_salonImagePath;
+    current_image_path[id] = 'img/notfound.jpg';
+    component_salon_image_path.setState({t_hairSalonMaster_salonImagePath: current_image_path});
+  });
+
 });


### PR DESCRIPTION
issue：#4

* サロン情報管理ページに画像削除ボタンを設置
* 地図情報管理ページに画像削除ボタンを設置

画像削除ボタンは押下時に画面上の画像を非表示にする。この状態で登録ボタンを押すことで画像削除が完了する。